### PR TITLE
Moves #include <x86intrin.h> from simd.h to simd.c

### DIFF
--- a/SIMDCSVParser/simd.c
+++ b/SIMDCSVParser/simd.c
@@ -7,6 +7,7 @@
 //
 
 #include "simd.h"
+#include <x86intrin.h>
 
 uint64_t cmp_mask_against_input(const uint8_t *ptr, uint8_t m) {
     const __m256i mask = _mm256_set1_epi8(m);

--- a/SIMDCSVParser/simd.h
+++ b/SIMDCSVParser/simd.h
@@ -10,7 +10,6 @@
 #define simd_h
 
 #include <stdio.h>
-#include <x86intrin.h>
 
 uint64_t cmp_mask_against_input(const uint8_t *ptr, uint8_t m);
 uint64_t carryless_multiply(uint64_t x, uint64_t y);


### PR DESCRIPTION
I don't think it was supposed to expose <x86intrin.h> in simd.h.